### PR TITLE
Per-category skip modes & Unskip support

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -212,4 +212,28 @@ public abstract class PlayerUi {
      */
     public void onVideoSizeChanged(@NonNull final VideoSize videoSize) {
     }
+
+    /**
+     * Show SponsorBlock segment un-skip button.
+     */
+    public void showAutoUnskip() {
+    }
+
+    /**
+     * Hide SponsorBlock segment un-skip button.
+     */
+    public void hideAutoUnskip() {
+    }
+
+    /**
+     * Show SponsorBlock segment skip button.
+     */
+    public void showAutoSkip() {
+    }
+
+    /**
+     * Hide SponsorBlock segment skip button.
+     */
+    public void hideAutoSkip() {
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -216,6 +216,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
         binding.repeatButton.setOnClickListener(v -> onRepeatClicked());
         binding.shuffleButton.setOnClickListener(v -> onShuffleClicked());
+        binding.unskipButton.setOnClickListener(v -> onUnskipClicked());
+        binding.skipButton.setOnClickListener(v -> onSkipClicked());
 
         binding.playPauseButton.setOnClickListener(makeOnClickListener(player::playPause));
         binding.playPreviousButton.setOnClickListener(makeOnClickListener(player::playPrevious));
@@ -292,6 +294,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
         binding.repeatButton.setOnClickListener(null);
         binding.shuffleButton.setOnClickListener(null);
+        binding.unskipButton.setOnClickListener(null);
+        binding.skipButton.setOnClickListener(null);
 
         binding.playPauseButton.setOnClickListener(null);
         binding.playPreviousButton.setOnClickListener(null);
@@ -857,6 +861,21 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.getRoot().setKeepScreenOn(true);
     }
 
+    public void showAutoUnskip() {
+        binding.unskipButton.setVisibility(View.VISIBLE);
+    }
+
+    public void hideAutoUnskip() {
+        binding.unskipButton.setVisibility(View.GONE);
+    }
+
+    public void showAutoSkip() {
+        binding.skipButton.setVisibility(View.VISIBLE);
+    }
+    public void hideAutoSkip() {
+        binding.skipButton.setVisibility(View.GONE);
+    }
+
     @Override
     public void onPaused() {
         super.onPaused();
@@ -951,6 +970,20 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
             Log.d(TAG, "onShuffleClicked() called");
         }
         player.toggleShuffleModeEnabled();
+    }
+
+    public void onUnskipClicked() {
+        if (DEBUG) {
+            Log.d(TAG, "onUnskipClicked() called");
+        }
+        player.toggleUnskip();
+    }
+
+    public void onSkipClicked() {
+        if (DEBUG) {
+            Log.d(TAG, "onSkipClicked() called");
+        }
+        player.toggleSkip();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/util/SponsorBlockSecondaryMode.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SponsorBlockSecondaryMode.java
@@ -1,0 +1,8 @@
+package org.schabi.newpipe.util;
+
+public enum SponsorBlockSecondaryMode {
+    DISABLED,
+    ENABLED,
+    MANUAL,
+    HIGHLIGHT
+}

--- a/app/src/main/res/drawable/background_rectangle_black_transparent.xml
+++ b/app/src/main/res/drawable/background_rectangle_black_transparent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#64000000" />
+    <corners android:radius="5dp"/>
+</shape>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -758,6 +758,75 @@
                     tools:src="@drawable/ic_brightness_high" />
             </RelativeLayout>
 
+            <RelativeLayout
+                android:id="@+id/unskipButton"
+                android:clickable="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_alignParentLeft="true"
+                android:layout_marginLeft="10dp"
+                android:background="@drawable/background_rectangle_black_transparent"
+                android:padding="@dimen/player_main_buttons_padding">
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/tooltipUnskipIcon"
+                    android:src="@drawable/ic_previous"
+                    android:clickable="false"
+                    app:tint="@color/white"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:scaleType="fitXY"
+                    android:layout_width="25dp"
+                    android:layout_height="25dp"
+                    android:layout_centerVertical="true" />
+
+                <TextView
+                    android:id="@+id/tooltipUnskipText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sponsor_block_manual_unskip_button"
+                    android:paddingRight="5dp"
+                    android:layout_toRightOf="@+id/tooltipUnskipIcon"
+                    android:layout_centerVertical="true"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                    android:textColor="#FFFFFF" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/skipButton"
+                android:clickable="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_alignParentRight="true"
+                android:layout_marginRight="10dp"
+                android:background="@drawable/background_rectangle_black_transparent"
+                android:visibility="gone"
+                android:padding="@dimen/player_main_buttons_padding">
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/tooltipSkipIcon"
+                    android:src="@drawable/ic_next"
+                    android:clickable="false"
+                    app:tint="@color/white"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:scaleType="fitXY"
+                    android:layout_width="25dp"
+                    android:layout_height="25dp"
+                    android:layout_toRightOf="@+id/tooltipSkipText"
+                    android:layout_centerVertical="true" />
+
+                <TextView
+                    android:id="@+id/tooltipSkipText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sponsor_block_manual_skip_button"
+                    android:paddingLeft="5dp"
+                    android:layout_centerVertical="true"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                    android:textColor="#FFFFFF" />
+            </RelativeLayout>
+
         </RelativeLayout>
 
     </RelativeLayout>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1478,26 +1478,42 @@
     <string name="sponsor_block_category_all_on_key" translatable="false">sponsor_block_category_all_on</string>
     <string name="sponsor_block_category_all_off_key" translatable="false">sponsor_block_category_all_off</string>
     <string name="sponsor_block_category_sponsor_key" translatable="false">sponsor_block_category_sponsor</string>
+    <string name="sponsor_block_category_sponsor_mode_key" translatable="false">sponsor_block_category_sponsor_mode</string>
     <string name="sponsor_block_category_sponsor_color_key" translatable="false">sponsor_block_category_sponsor_color</string>
     <string name="sponsor_block_category_intro_key" translatable="false">sponsor_block_category_intro</string>
+    <string name="sponsor_block_category_intro_mode_key" translatable="false">sponsor_block_category_intro_mode</string>
     <string name="sponsor_block_category_intro_color_key" translatable="false">sponsor_block_category_intro_color</string>
     <string name="sponsor_block_category_outro_key" translatable="false">sponsor_block_category_outro</string>
+    <string name="sponsor_block_category_outro_mode_key" translatable="false">sponsor_block_category_outro_mode</string>
     <string name="sponsor_block_category_outro_color_key" translatable="false">sponsor_block_category_outro_color</string>
     <string name="sponsor_block_category_interaction_key" translatable="false">sponsor_block_category_interaction</string>
+    <string name="sponsor_block_category_interaction_mode_key" translatable="false">sponsor_block_category_interaction_mode</string>
     <string name="sponsor_block_category_interaction_color_key" translatable="false">sponsor_block_category_interaction_color</string>
     <string name="sponsor_block_category_highlight_key" translatable="false">sponsor_block_category_highlight</string>
     <string name="sponsor_block_category_highlight_color_key" translatable="false">sponsor_block_category_highlight_color</string>
     <string name="sponsor_block_category_self_promo_key" translatable="false">sponsor_block_category_self_promo</string>
+    <string name="sponsor_block_category_self_promo_mode_key" translatable="false">sponsor_block_category_promo_mode</string>
     <string name="sponsor_block_category_self_promo_color_key" translatable="false">sponsor_block_category_self_promo_color</string>
     <string name="sponsor_block_category_non_music_key" translatable="false">sponsor_block_category_music</string>
+    <string name="sponsor_block_category_non_music_mode_key" translatable="false">sponsor_block_category_music_mode</string>
     <string name="sponsor_block_category_non_music_color_key" translatable="false">sponsor_block_category_music_color</string>
     <string name="sponsor_block_category_preview_key" translatable="false">sponsor_block_category_preview</string>
+    <string name="sponsor_block_category_preview_mode_key" translatable="false">sponsor_block_category_preview_mode</string>
     <string name="sponsor_block_category_preview_color_key" translatable="false">sponsor_block_category_preview_color</string>
     <string name="sponsor_block_category_filler_key" translatable="false">sponsor_block_category_filler</string>
+    <string name="sponsor_block_category_filler_mode_key" translatable="false">sponsor_block_category_filler_mode</string>
     <string name="sponsor_block_category_filler_color_key" translatable="false">sponsor_block_category_filler_color</string>
     <string name="sponsor_block_category_pending_key" translatable="false">sponsor_block_category_pending_key</string>
     <string name="sponsor_block_category_pending_color_key" translatable="false">sponsor_block_category_pending_color_key</string>
     <string name="sponsor_block_clear_whitelist_key" translatable="false">sponsor_block_clear_whitelist</string>
+    <string name="sponsor_block_graced_rewind_key" translatable="false">sponsor_block_skip</string>
+    <string name="sponsor_block_show_manual_skip_key" translatable="false">sponsor_block_skip</string>
+
+    <string-array name="sponsor_block_category_sponsor_modes_key">
+        <item>@string/sponsor_block_skip_mode_enabled</item>
+        <item>@string/sponsor_block_skip_mode_manual</item>
+        <item>@string/sponsor_block_skip_mode_highlight</item>
+    </string-array>
 
     <!-- ReturnYouTubeDislike -->
     <string name="return_youtube_dislike_home_page_key" translatable="false">return_youtube_dislike_home_page</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -910,6 +910,7 @@
     <string name="settings_category_sponsor_block_categories_all_colors_on_title">All On</string>
     <string name="settings_category_sponsor_block_categories_all_colors_off_title">All Off</string>
     <string name="settings_category_sponsor_block_category_enable_title">Enable</string>
+    <string name="settings_category_sponsor_block_category_enable_mode_title">Skip Mode</string>
     <string name="settings_category_sponsor_block_category_color">Seek Bar Color</string>
     <string name="settings_category_sponsor_block_category_sponsor_summary">Paid promotion, paid referrals and direct advertisements. Not for self-promotion or free shoutouts to causes/creators/websites/products they like.</string>
     <string name="settings_category_sponsor_block_category_intro_summary">An interval without actual content. Could be a pause, static frame, repeating animation. This should not be used for transitions containing information or be used on music videos.</string>
@@ -929,6 +930,15 @@
     <string name="description_up_vote_segment">Up-vote segment</string>
     <string name="description_down_vote_segment">Down-vote segment</string>
     <string name="description_skip_to_highlight">Skip to highlight</string>
+    <string name="sponsor_block_skip_mode_enabled">Automatic</string>
+    <string name="sponsor_block_skip_mode_manual">Manual</string>
+    <string name="sponsor_block_skip_mode_highlight">Highlight Only</string>
+    <string name="sponsor_block_graced_rewind_title">Rewind pauses skipping</string>
+    <string name="sponsor_block_graced_rewind_summary">Rewinding the video back into automatically skipped segments will pause segment skipping until the segment ends.</string>
+    <string name="sponsor_block_manual_unskip_button">Un-skip</string>
+    <string name="sponsor_block_manual_skip_button">Skip</string>
+    <string name="sponsor_block_show_manual_skip_title">Shows Manual Buttons.</string>
+    <string name="sponsor_block_show_manual_skip_summary">Shows buttons on-screen to manually skip/unskip segments. It is recommended to enable this when configuring SponsorBlock Categories to use Manual Skipping.</string>
     <!-- ReturnYouTubeDislike -->
     <string name="return_youtube_dislike_home_page_title">View Website</string>
     <string name="return_youtube_dislike_home_page_summary">View the official ReturnYouTubeDislike website.</string>

--- a/app/src/main/res/xml/sponsor_block_category_settings.xml
+++ b/app/src/main/res/xml/sponsor_block_category_settings.xml
@@ -37,6 +37,17 @@
             android:key="@string/sponsor_block_category_sponsor_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
 
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_sponsor_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_sponsor_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
+
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
             android:dependency="@string/sponsor_block_category_sponsor_key"
@@ -60,6 +71,17 @@
             android:defaultValue="true"
             android:key="@string/sponsor_block_category_intro_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
+
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_intro_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_intro_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
 
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
@@ -85,6 +107,17 @@
             android:key="@string/sponsor_block_category_outro_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
 
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_outro_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_outro_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
+
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
             android:dependency="@string/sponsor_block_category_outro_key"
@@ -108,6 +141,17 @@
             android:defaultValue="true"
             android:key="@string/sponsor_block_category_interaction_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
+
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_interaction_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_interaction_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
 
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
@@ -157,6 +201,17 @@
             android:key="@string/sponsor_block_category_self_promo_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
 
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_self_promo_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_self_promo_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
+
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
             android:dependency="@string/sponsor_block_category_self_promo_key"
@@ -180,6 +235,17 @@
             android:defaultValue="true"
             android:key="@string/sponsor_block_category_non_music_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
+
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_non_music_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_non_music_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
 
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
@@ -205,6 +271,17 @@
             android:key="@string/sponsor_block_category_preview_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
 
+        <ListPreference
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_preview_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_preview_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title" />
+
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"
             android:dependency="@string/sponsor_block_category_preview_key"
@@ -228,6 +305,18 @@
             android:defaultValue="true"
             android:key="@string/sponsor_block_category_filler_key"
             android:title="@string/settings_category_sponsor_block_category_enable_title"/>
+
+        <ListPreference
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="@string/sponsor_block_category_filler_key"
+            android:defaultValue="@string/sponsor_block_skip_mode_enabled"
+            android:entries="@array/sponsor_block_category_sponsor_modes_key"
+            android:entryValues="@array/sponsor_block_category_sponsor_modes_key"
+            android:key="@string/sponsor_block_category_filler_mode_key"
+            android:title="@string/settings_category_sponsor_block_category_enable_mode_title"
+            />
 
         <org.schabi.newpipe.settings.custom.EditColorPreference
             app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/sponsor_block_settings.xml
+++ b/app/src/main/res/xml/sponsor_block_settings.xml
@@ -38,6 +38,22 @@
             app:iconSpaceReserved="false"
             android:dependency="@string/sponsor_block_enable_key"
             android:defaultValue="true"
+            android:key="@string/sponsor_block_show_manual_skip_key"
+            android:summary="@string/sponsor_block_show_manual_skip_summary"
+            android:title="@string/sponsor_block_show_manual_skip_title"/>
+
+        <SwitchPreference
+            app:iconSpaceReserved="false"
+            android:dependency="@string/sponsor_block_enable_key"
+            android:defaultValue="true"
+            android:key="@string/sponsor_block_graced_rewind_key"
+            android:summary="@string/sponsor_block_graced_rewind_summary"
+            android:title="@string/sponsor_block_graced_rewind_title"/>
+
+        <SwitchPreference
+            app:iconSpaceReserved="false"
+            android:dependency="@string/sponsor_block_enable_key"
+            android:defaultValue="true"
             android:key="@string/sponsor_block_notifications_key"
             android:summary="@string/sponsor_block_notifications_summary"
             android:title="@string/sponsor_block_notifications_title"/>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Hi. I have been brutally stabbed too many times to count by CheckStyle. In my dying breaths... I bring you per-category skip settings and "un-skipping" of segments.


- When within a segment, added an option to manually skip. This is controlled by "Show manual buttons"
- Added ability to un-skip auto skipped segments for 5 seconds after the segment elapses
- Added a toggle to allow "rewinding" into segments (ex. double tap to re-watch skipped segment will actually allow you to watch the segment). This is controlled via "Rewind pauses skipping"
- Per-segment category skip options (Automatic, manual, highlight only). This is controlled by "Skip Mode" from within SponsorBlock Categories


#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- After:
![tubular_demo](https://github.com/polymorphicshade/Tubular/assets/50182620/4e3c3c7c-1176-4442-b6ea-62e218f12f89)

#### Settings
The default settings are:
- Show manual buttons : on
- Rewind pauses skipping: on
- SponsorBlock Categories: Skip Mode defaults to "Automatic", a.k.a mimicing the existing behavour of the Enable toggle

#### Extra notes
- Tested on Android 14 (LineageOS 21)
- Buttons may be offset weirdly when rotating the device.
    - I am pretty sure is an upstream issue (the underlying view/container does that)
- Why are you creating a whole new button for an icon when you can replace it all with:
    - `
app:drawableLeftCompat="@drawable/ic_previous"
android:drawableTint="@color/white" 
`
    - SDK drawableTint requires SDK 23 (we are on 21)
 - Possibility of not vertically centered skip/un-skip buttons, they are however aligned with the play button... which I just found out also isn't centered

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
