### PR TITLE
Fix unskip on certain segment

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2501,7 +2501,13 @@ public final class Player implements PlaybackListener, Listener {
             if (lastSegment != null
                     && progress > lastSegment.endTime + UNSKIP_WINDOW_MILLIS) {
                 // un-skip window is over
-                destroyUnskipVars();
+                hideUnskipButtons();
+                lastSegment = null;
+                autoSkipGracePeriod = false;
+
+                if (DEBUG) {
+                    Log.d("SPONSOR_BLOCK", "Destroyed last segment variables (UNSKIP)");
+                }
             } else if (lastSegment != null
                     && progress < lastSegment.endTime + UNSKIP_WINDOW_MILLIS
                     && progress >= lastSegment.startTime) {
@@ -2509,17 +2515,15 @@ public final class Player implements PlaybackListener, Listener {
                 return lastSegment;
             }
 
-            destroyUnskipVars();
+            hideUnskipButtons();
             return null;
         });
     }
 
-    private void destroyUnskipVars() {
+    private void hideUnskipButtons() {
         if (DEBUG) {
-            Log.d("SPONSOR_BLOCK", "Destroying last segment variables, hiding manual skip buttons");
+            Log.d("SPONSOR_BLOCK", "Hiding manual skip buttons (UNSKIP)");
         }
-        lastSegment = null;
-        autoSkipGracePeriod = false;
         UIs.call(PlayerUi::hideAutoSkip);
         UIs.call(PlayerUi::hideAutoUnskip);
     }


### PR DESCRIPTION
Hewwo! This address an bug where unskip functionality may break (where you trigger unskip but it automatically re-skips anyways) when two segments are very close to each other (I think). I am not exactly sure of the cause, however it applies to certain videos. See 3:15:00 --> https://www.youtube.com/live/1ThO140eQY4?si=Vpb9A5eE7xeK2cuf&t=11700


Code wise, it separates hiding buttons and the destruction of unskip tracking variables. I believe this also is present on release versions, but my memory is fuzzy.

