### PR TITLE
build and release the app using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout branch "${{ github.ref_name }}"
         run: |
-          git clone --no-checkout https://github.com/thekyber/Tubular.git .
+          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
           git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
         
@@ -41,9 +41,8 @@ jobs:
         run: |
           version=$( grep "versionName" app/build.gradle | awk -F'"' '{print $2}' )
           gh auth login --with-token <<<"${{ secrets.GH_TOKEN }}"
-          ls -la
-          gh release create "v$version" --title "v$version" --notes-file "changelog.md" --prerelease=false --repo thekyber/Tubular
-          gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo thekyber/Tubular
+          gh release create "v$version" --title "v$version" --notes-file "changelog.md" --prerelease=false --repo polymorphicshade/Tubular
+          gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo polymorphicshade/Tubular
 
       - name: archive reports for job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           version=$( grep "versionName" app/build.gradle | awk -F'"' '{print $2}' )
           gh auth login --with-token <<<"${{ secrets.GH_TOKEN }}"
+          ls -la
           gh release create "v$version" --title "v$version" --notes-file "changelog.md" --prerelease=false --repo thekyber/Tubular
           gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo thekyber/Tubular
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           version=$( grep "versionName" app/build.gradle | awk -F'"' '{print $2}' )
           gh auth login --with-token <<<"${{ secrets.GH_TOKEN }}"
-          gh release create "v$version" --title "v$version" --notes "" --prerelease=false --repo polymorphicshade/Tubular
-          gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo polymorphicshade/Tubular
+          gh release create "v$version" --title "v$version" --notes-file "changelog.md" --prerelease=false --repo thekyber/Tubular
+          gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo thekyber/Tubular
 
       - name: archive reports for job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout branch "${{ github.ref_name }}"
         run: |
-          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
+          git clone --no-checkout https://github.com/thekyber/Tubular.git .
           git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout branch "${{ github.ref_name }}"
         run: |
-          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
+          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git
           git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions: write-all
 
     steps:
-      - name: Checkout branch "${{ github.ref_name }}"
+      - name: checkout branch "${{ github.ref_name }}"
         run: |
           git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
           git config core.symlinks false
@@ -23,7 +23,7 @@ jobs:
           distribution: "temurin"
           cache: 'gradle'
 
-      - name: Build release APK
+      - name: build release APK
         run: ./gradlew assembleRelease
 
       - name: sign APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout branch "${{ github.ref_name }}"
         run: |
-          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git
+          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
           git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,48 @@ on:
 
 jobs:
   build-and-release:
-
     runs-on: ubuntu-latest
+    
+    permissions: write-all
 
     steps:
-      - name: Print environment
-        run: env | grep ^GITHUB
+      - name: Checkout branch "${{ github.ref_name }}"
+        run: |
+          git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
+          git config core.symlinks false
+          git checkout --progress --force ${{ github.ref_name }}
+        
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+          cache: 'gradle'
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: sign APK
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}    
+       
+        run: |
+          version=$( grep "versionName" app/build.gradle | awk -F'"' '{print $2}' )
+          echo "${KEYSTORE_BASE64}" | base64 -d > apksign.keystore
+          ${ANDROID_HOME}/build-tools/34.0.0/apksigner sign --ks apksign.keystore --ks-pass env:KEYSTORE_PASSWORD "app/build/outputs/apk/release/app-release-unsigned.apk"
+          mv app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/"tubular_v$version.apk"
+
+      - name: create release and upload
+        run: |
+          version=$( grep "versionName" app/build.gradle | awk -F'"' '{print $2}' )
+          gh auth login --with-token <<<"${{ secrets.GH_TOKEN }}"
+          gh release create "v$version" --title "v$version" --notes "" --prerelease=false --repo polymorphicshade/Tubular
+          gh release upload "v$version" app/build/outputs/apk/release/*.apk --repo polymorphicshade/Tubular
+
+      - name: archive reports for job
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: '*/build/reports'
+        if: ${{ always() }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,1 @@
-## To Do
-Things I'll be working on next (not in any particular order):
-- [ ] persist custom SponsorBlock segments in the database
-- [ ] add SponsorBlock's "Exclusive Access" / "Sponsored Video feature"
-- [ ] add SponsorBlock's chapters feature
-- [ ] add a clickbait-remover
-- [ ] add keyword/regex filtering
-- [ ] add subscription importing with a YouTube login cookie
-- [ ] add algorithmic results with a YouTube login cookie
-- [ ] add offline YouTube playback
-
-## License
-[![GNU GPLv3](https://www.gnu.org/graphics/gplv3-127x51.png)](https://www.gnu.org/licenses/gpl-3.0.en.html)
+## Your release notes

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,13 @@
+## To Do
+Things I'll be working on next (not in any particular order):
+- [ ] persist custom SponsorBlock segments in the database
+- [ ] add SponsorBlock's "Exclusive Access" / "Sponsored Video feature"
+- [ ] add SponsorBlock's chapters feature
+- [ ] add a clickbait-remover
+- [ ] add keyword/regex filtering
+- [ ] add subscription importing with a YouTube login cookie
+- [ ] add algorithmic results with a YouTube login cookie
+- [ ] add offline YouTube playback
+
+## License
+[![GNU GPLv3](https://www.gnu.org/graphics/gplv3-127x51.png)](https://www.gnu.org/licenses/gpl-3.0.en.html)


### PR DESCRIPTION
Should solve #52

I believe that my work is complete, this workflow will handle everything from building to signing to creating a relevant tag and release names that are extracted from `app/build.gradle`.

All you need is to launch it when you like to publish a new release.

It is tested and it works pretty well as you can see [here](https://github.com/thekyber/Tubular/actions/runs/8766742131).

You can also check the [release page](https://github.com/thekyber/Tubular/releases) to see the tag and release name, and I also made it to rename the apk file to match yours.

You just have to add `KEYSTORE_BASE64` and `KEYSTORE_PASSWORD` and `GH_TOKEN` with the relevant permissons so it can create the release and upload the files.