### PR TITLE
Update the app name within the default file name for database exports

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -88,7 +88,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
             NoFileManagerSafeGuard.launchSafe(
                     requestExportPathLauncher,
                     StoredFileHelper.getNewPicker(requireContext(),
-                            "NewPipeData-" + exportDateFormat.format(new Date()) + ".zip",
+                            "TubularData-" + exportDateFormat.format(new Date()) + ".zip",
                             ZIP_MIME_TYPE, getImportExportDataUri()),
                     TAG,
                     getContext()


### PR DESCRIPTION
Fixes https://github.com/polymorphicshade/Tubular/issues/92

This change appears to be the equivalent of the change the fork PipePipe made to `app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java` in [PipePipeClient commit ef088a96](https://codeberg.org/NullPointerException/PipePipeClient/commit/ef088a966eebed05ba205bf654d3e029ea59664f), suggesting this line is safe to change.

I did not build the app to test this change. If you worry that more changes may be needed in other files to fix this, feel free to just use this PR as inspiration for the full fix.