### PR TITLE
Remove core.symlinks=false git config from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Checkout branch "${{ github.ref_name }}"
         run: |
           git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
-          git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
 
       - name: Set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout branch "${{ github.ref_name }}"
         run: |
           git clone --no-checkout https://github.com/polymorphicshade/Tubular.git .
-          git config core.symlinks false
           git checkout --progress --force ${{ github.ref_name }}
         
       - name: Set up JDK 17


### PR DESCRIPTION
That is unnecessary after https://github.com/polymorphicshade/Tubular/issues/60.
It should ease reproducible builds and prevent regressions.

Additionally: Should you remove the `--force` flag from `git checkout`? Or switch entirely to the [checkout action](https://github.com/marketplace/actions/checkout)?