### PR TITLE
Option to adjust playback speed (tempo) via middle gesture on main player screen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -893,6 +893,10 @@ public final class Player implements PlaybackListener, Listener {
         return getPlaybackParameters().pitch;
     }
 
+    public void setPlaybackPitch(final float pitch) {
+        setPlaybackParameters(getPlaybackSpeed(), pitch, getPlaybackSkipSilence());
+    }
+
     public boolean getPlaybackSkipSilence() {
         return !exoPlayerIsNull() && simpleExoPlayer.getSkipSilenceEnabled();
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -60,7 +60,7 @@ public class PlaybackParameterDialog extends DialogFragment {
     private static final double DEFAULT_PITCH_PERCENT = 1.00f;
     private static final double DEFAULT_STEP = STEP_25_PERCENT_VALUE;
     private static final boolean DEFAULT_SKIP_SILENCE = false;
-
+    private static final boolean DEFAULT_PLAYBACK_UNHOOK = false;
     private static final SliderStrategy QUADRATIC_STRATEGY = new SliderStrategy.Quadratic(
             MIN_PITCH_OR_SPEED,
             MAX_PITCH_OR_SPEED,
@@ -261,7 +261,7 @@ public class PlaybackParameterDialog extends DialogFragment {
         bindCheckboxWithBoolPref(
                 binding.unhookCheckbox,
                 R.string.playback_unhook_key,
-                true,
+                DEFAULT_PLAYBACK_UNHOOK,
                 isChecked -> {
                     if (!isChecked) {
                         // when unchecked, slide back to the minimum of current tempo or pitch
@@ -588,6 +588,32 @@ public class PlaybackParameterDialog extends DialogFragment {
     @NonNull
     private static String getPercentString(final double percent) {
         return PlayerHelper.formatPitch(percent);
+    }
+
+
+    public static boolean getPlaybackUnhooked(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.playback_unhook_key),
+                        DEFAULT_PLAYBACK_UNHOOK);
+    }
+
+    public static boolean getPitchControlModeSemitone(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.playback_adjust_by_semitones_key),
+                        PITCH_CTRL_MODE_PERCENT);
+    }
+
+    public static float getCurrentStepSize(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getFloat(context.getString(R.string.adjustment_step_key), (float) DEFAULT_STEP);
+    }
+
+    public static float getMinPitchOrSpeed() {
+        return (float) MIN_PITCH_OR_SPEED;
+    }
+
+    public static float getMaxPitchOrSpeed() {
+        return (float) MAX_PITCH_OR_SPEED;
     }
 
     public interface Callback {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -234,6 +234,12 @@ public final class PlayerHelper {
                         context.getString(R.string.default_right_gesture_control_value));
     }
 
+    public static String getActionForMiddleGestureSide(@NonNull final Context context) {
+        return getPreferences(context)
+                .getString(context.getString(R.string.middle_gesture_control_key),
+                        context.getString(R.string.default_middle_gesture_control_value));
+    }
+
     public static String getActionForLeftGestureSide(@NonNull final Context context) {
         return getPreferences(context)
                 .getString(context.getString(R.string.left_gesture_control_key),

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -551,6 +551,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
             binding.volumeProgressBar.setMax(maxGestureLength);
             binding.brightnessProgressBar.setMax(maxGestureLength);
+            binding.playbackSpeedProgressBar.setMax(maxGestureLength);
 
             setInitialGestureValues();
             binding.itemsListPanel.getLayoutParams().height =

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -759,6 +759,34 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/playbackSpeedRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/playbackSpeedProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <TextView
+                    android:id="@+id/playbackSpeedTextView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    android:gravity="center"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    tools:ignore="ContentDescription" />
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/unskipButton"
                 android:visibility="gone"
                 android:clickable="true"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -729,8 +729,9 @@
     <string name="feed_show_upcoming">Demnächst</string>
     <string name="feed_show_watched">Vollständig angeschaut</string>
     <string name="feed_show_partially_watched">Teilweise angeschaut</string>
-    <string name="left_gesture_control_summary">Geste für die linke Hälfte des Player-Bildschirms auswählen</string>
-    <string name="right_gesture_control_summary">Geste für die rechte Hälfte des Player-Bildschirms auswählen</string>
+    <string name="left_gesture_control_summary">Geste für den linken Teil des Player-Bildschirms auswählen</string>
+    <string name="middle_gesture_control_title">Mittlere Gestenaktion</string>
+    <string name="right_gesture_control_summary">Geste für den rechten Teil des Player-Bildschirms auswählen</string>
     <string name="none">Keine</string>
     <string name="right_gesture_control_title">Rechte Gestenaktion</string>
     <string name="left_gesture_control_title">Linke Gestenaktion</string>
@@ -826,4 +827,5 @@
 \nMöchtest du wirklich fortfahren?</string>
     <string name="import_settings_vulnerable_format">Die Einstellungen in dem zu importierenden Export verwenden ein angreifbares Format, das seit NewPipe 0.27.0 veraltet ist. Stellen Sie sicher, dass der zu importierende Export aus einer vertrauenswürdigen Quelle stammt, und verwenden Sie in Zukunft nur noch Exporte, die aus NewPipe 0.27.0 oder neuer stammen. Die Unterstützung für den Import von Einstellungen in diesem angreifbaren Format wird bald vollständig entfernt werden, und dann werden alte Versionen von NewPipe nicht mehr in der Lage sein, Einstellungen von Exporten aus neuen Versionen zu importieren.</string>
     <string name="audio_track_type_secondary">Sekundär</string>
+    <string name="middle_gesture_control_summary">Geste für den mittleren Teil des Player-Bildschirms auswählen</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -204,28 +204,48 @@
     <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string name="brightness_control_key">brightness_control</string>
     <string name="volume_control_key">volume_control</string>
+    <string name="playback_speed_control_key">playback_speed_control</string>
     <string name="none_control_key">none_control</string>
     <string-array name="left_gesture_control_description">
         <item>@string/brightness</item>
         <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
         <item>@string/none</item>
     </string-array>
     <string-array name="left_gesture_control_values">
         <item>@string/brightness_control_key</item>
         <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
+        <item>@string/none_control_key</item>
+    </string-array>
+
+    <string name="middle_gesture_control_key">middle_gesture_control</string>
+    <string name="default_middle_gesture_control_value">@string/playback_speed_control_key</string>
+    <string-array name="middle_gesture_control_description">
+        <item>@string/brightness</item>
+        <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
+        <item>@string/none</item>
+    </string-array>
+    <string-array name="middle_gesture_control_values">
+        <item>@string/brightness_control_key</item>
+        <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
     </string-array>
 
     <string name="right_gesture_control_key">right_gesture_control</string>
     <string name="default_right_gesture_control_value">@string/volume_control_key</string>
     <string-array name="right_gesture_control_description">
-        <item>@string/volume</item>
         <item>@string/brightness</item>
+        <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
         <item>@string/none</item>
     </string-array>
     <string-array name="right_gesture_control_values">
-        <item>@string/volume_control_key</item>
         <item>@string/brightness_control_key</item>
+        <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
     </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,9 +106,11 @@
     <string name="auto_queue_title">Auto-enqueue next stream</string>
     <string name="auto_queue_summary">Continue ending (non-repeating) playback queue by appending a related stream</string>
     <string name="auto_queue_toggle">Auto-enqueuing</string>
-    <string name="left_gesture_control_summary">Choose gesture for left half of player screen</string>
+    <string name="left_gesture_control_summary">Choose gesture for left part of player screen</string>
     <string name="left_gesture_control_title">Left gesture action</string>
-    <string name="right_gesture_control_summary">Choose gesture for right half of player screen</string>
+    <string name="middle_gesture_control_summary">Choose gesture for middle part of player screen</string>
+    <string name="middle_gesture_control_title">Middle gesture action</string>
+    <string name="right_gesture_control_summary">Choose gesture for right part of player screen</string>
     <string name="right_gesture_control_title">Right gesture action</string>
     <string name="brightness">Brightness</string>
     <string name="volume">Volume</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -199,6 +199,16 @@
             app:iconSpaceReserved="false" />
 
         <ListPreference
+            android:defaultValue="@string/default_middle_gesture_control_value"
+            android:entries="@array/middle_gesture_control_description"
+            android:entryValues="@array/middle_gesture_control_values"
+            android:key="@string/middle_gesture_control_key"
+            android:summary="@string/middle_gesture_control_summary"
+            android:title="@string/middle_gesture_control_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
+        <ListPreference
             android:defaultValue="@string/default_right_gesture_control_value"
             android:entries="@array/right_gesture_control_description"
             android:entryValues="@array/right_gesture_control_values"


### PR DESCRIPTION
Add third gesture area in the middle third of player screen
Add third gesture option: tempo / playback speed
Add settings item for middle gesture

Already working (for 3 weeks) and beloved (by some people) feature in [MaintainTeam/LastPipeBender](https://github.com/MaintainTeam/LastPipeBender)