### PR TITLE
Allow to choose max playback speed in settings to your liking

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -156,7 +156,7 @@ class MainPlayerGestureListener(
 
     private fun onScrollPlaybackSpeed(distanceY: Float) {
         val bar: ProgressBar = binding.playbackSpeedProgressBar
-        val maxPlaybackSpeed: Float = PlaybackParameterDialog.getMaxPitchOrSpeed()
+        val maxPlaybackSpeed: Float = PlaybackParameterDialog.getMaxPitchOrSpeed(player.context)
         val minPlaybackSpeed: Float = PlaybackParameterDialog.getMinPitchOrSpeed()
         val playbackSpeedStep: Float = PlaybackParameterDialog.getCurrentStepSize(player.context) / maxPlaybackSpeed
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -45,8 +45,6 @@ public class PlaybackParameterDialog extends DialogFragment {
 
     // Minimum allowable range in ExoPlayer
     private static final double MIN_PITCH_OR_SPEED = 0.10f;
-    private static final double MAX_PITCH_OR_SPEED = 5.00f;
-
     private static final boolean PITCH_CTRL_MODE_PERCENT = false;
     private static final boolean PITCH_CTRL_MODE_SEMITONE = true;
 
@@ -61,12 +59,6 @@ public class PlaybackParameterDialog extends DialogFragment {
     private static final double DEFAULT_STEP = STEP_25_PERCENT_VALUE;
     private static final boolean DEFAULT_SKIP_SILENCE = false;
     private static final boolean DEFAULT_PLAYBACK_UNHOOK = false;
-    private static final SliderStrategy QUADRATIC_STRATEGY = new SliderStrategy.Quadratic(
-            MIN_PITCH_OR_SPEED,
-            MAX_PITCH_OR_SPEED,
-            1.00f,
-            10_000);
-
     private static final SliderStrategy SEMITONE_STRATEGY = new SliderStrategy() {
         @Override
         public int progressOf(final double value) {
@@ -177,14 +169,17 @@ public class PlaybackParameterDialog extends DialogFragment {
 
     private void initUI() {
         // Tempo
-        setText(binding.tempoMinimumText, PlayerHelper::formatSpeed, MIN_PITCH_OR_SPEED);
-        setText(binding.tempoMaximumText, PlayerHelper::formatSpeed, MAX_PITCH_OR_SPEED);
+        final float maxPitchOrSpeed = getMaxPitchOrSpeed(requireContext());
+        final SliderStrategy quadraticStrategy = getQuadraticStrategy(requireContext());
 
-        binding.tempoSeekbar.setMax(QUADRATIC_STRATEGY.progressOf(MAX_PITCH_OR_SPEED));
+        setText(binding.tempoMinimumText, PlayerHelper::formatSpeed, MIN_PITCH_OR_SPEED);
+        setText(binding.tempoMaximumText, PlayerHelper::formatSpeed, maxPitchOrSpeed);
+
+        binding.tempoSeekbar.setMax(quadraticStrategy.progressOf(maxPitchOrSpeed));
         setAndUpdateTempo(tempo);
         binding.tempoSeekbar.setOnSeekBarChangeListener(
                 getTempoOrPitchSeekbarChangeListener(
-                        QUADRATIC_STRATEGY,
+                        quadraticStrategy,
                         this::onTempoSliderUpdated));
 
         registerOnStepClickListener(
@@ -216,13 +211,13 @@ public class PlaybackParameterDialog extends DialogFragment {
 
         // Pitch - Percent
         setText(binding.pitchPercentMinimumText, PlayerHelper::formatPitch, MIN_PITCH_OR_SPEED);
-        setText(binding.pitchPercentMaximumText, PlayerHelper::formatPitch, MAX_PITCH_OR_SPEED);
+        setText(binding.pitchPercentMaximumText, PlayerHelper::formatPitch, maxPitchOrSpeed);
 
-        binding.pitchPercentSeekbar.setMax(QUADRATIC_STRATEGY.progressOf(MAX_PITCH_OR_SPEED));
+        binding.pitchPercentSeekbar.setMax(quadraticStrategy.progressOf(maxPitchOrSpeed));
         setAndUpdatePitch(pitchPercent);
         binding.pitchPercentSeekbar.setOnSeekBarChangeListener(
                 getTempoOrPitchSeekbarChangeListener(
-                        QUADRATIC_STRATEGY,
+                        quadraticStrategy,
                         this::onPitchPercentSliderUpdated));
 
         registerOnStepClickListener(
@@ -488,6 +483,13 @@ public class PlaybackParameterDialog extends DialogFragment {
     // Sliders
     //////////////////////////////////////////////////////////////////////////*/
 
+    private SliderStrategy getQuadraticStrategy(final Context context) {
+        return new SliderStrategy.Quadratic(
+                MIN_PITCH_OR_SPEED, getMaxPitchOrSpeed(context),
+                1.00f,
+                10_000);
+    }
+
     private SeekBar.OnSeekBarChangeListener getTempoOrPitchSeekbarChangeListener(
             final SliderStrategy sliderStrategy,
             final DoubleConsumer newValueConsumer
@@ -527,16 +529,18 @@ public class PlaybackParameterDialog extends DialogFragment {
     }
 
     private void setAndUpdateTempo(final double newTempo) {
-        this.tempo = MathUtils.clamp(newTempo, MIN_PITCH_OR_SPEED, MAX_PITCH_OR_SPEED);
+        this.tempo = MathUtils.clamp(newTempo, MIN_PITCH_OR_SPEED,
+                getMaxPitchOrSpeed(requireContext()));
 
-        binding.tempoSeekbar.setProgress(QUADRATIC_STRATEGY.progressOf(tempo));
+        binding.tempoSeekbar.setProgress(getQuadraticStrategy(requireContext()).progressOf(tempo));
         setText(binding.tempoCurrentText, PlayerHelper::formatSpeed, tempo);
     }
 
     private void setAndUpdatePitch(final double newPitch) {
         this.pitchPercent = calcValidPitch(newPitch);
 
-        binding.pitchPercentSeekbar.setProgress(QUADRATIC_STRATEGY.progressOf(pitchPercent));
+        binding.pitchPercentSeekbar.setProgress(getQuadraticStrategy(requireContext())
+                .progressOf(pitchPercent));
         binding.pitchSemitoneSeekbar.setProgress(SEMITONE_STRATEGY.progressOf(pitchPercent));
         setText(binding.pitchPercentCurrentText,
                 PlayerHelper::formatPitch,
@@ -547,7 +551,8 @@ public class PlaybackParameterDialog extends DialogFragment {
     }
 
     private double calcValidPitch(final double newPitch) {
-        final double calcPitch = MathUtils.clamp(newPitch, MIN_PITCH_OR_SPEED, MAX_PITCH_OR_SPEED);
+        final double calcPitch = MathUtils.clamp(newPitch, MIN_PITCH_OR_SPEED,
+                getMaxPitchOrSpeed(requireContext()));
 
         if (!isCurrentPitchControlModeSemitone()) {
             return calcPitch;
@@ -612,11 +617,13 @@ public class PlaybackParameterDialog extends DialogFragment {
         return (float) MIN_PITCH_OR_SPEED;
     }
 
-    public static float getMaxPitchOrSpeed() {
-        return (float) MAX_PITCH_OR_SPEED;
+    public static float getMaxPitchOrSpeed(final Context context) {
+        return Float.parseFloat(PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(context.getString(R.string.max_playback_speed_key),
+                        context.getString(R.string.default_max_playback_speed_value)));
     }
 
-    public interface Callback {
+        public interface Callback {
         void onPlaybackParameterChanged(float playbackTempo, float playbackPitch,
                                         boolean playbackSkipSilence);
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,8 @@
     <string name="popup_remember_size_pos_title">Eigenschaften des Pop-ups merken</string>
     <string name="use_external_video_player_summary">Entfernt Tonspur bei manchen Auflösungen</string>
     <string name="popup_remember_size_pos_summary">Letzte Größe und Position des Pop-ups merken</string>
+    <string name="max_playback_speed_title">Maximale Geschwindigkeit</string>
+    <string name="max_playback_speed_summary">Maximale Wiedergabegeschwindigkeit festlegen</string>
     <string name="show_search_suggestions_title">Suchvorschläge</string>
     <string name="show_search_suggestions_summary">Vorschläge auswählen, die bei der Suche angezeigt werden sollen</string>
     <string name="clear">löschen</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -200,12 +200,13 @@
         <item>@string/audio_webm_key</item>
     </string-array>
 
-    <string name="left_gesture_control_key">left_gesture_control</string>
-    <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string name="brightness_control_key">brightness_control</string>
     <string name="volume_control_key">volume_control</string>
     <string name="playback_speed_control_key">playback_speed_control</string>
     <string name="none_control_key">none_control</string>
+
+    <string name="left_gesture_control_key">left_gesture_control</string>
+    <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string-array name="left_gesture_control_description">
         <item>@string/brightness</item>
         <item>@string/volume</item>
@@ -247,6 +248,21 @@
         <item>@string/volume_control_key</item>
         <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
+    </string-array>
+
+    <string name="max_playback_speed_key">max_playback_speed</string>
+    <string name="default_max_playback_speed_value">5</string>
+    <string-array name="max_playback_speed_description">
+        <item>2x</item>
+        <item>3x</item>
+        <item>5x</item>
+        <item>10x</item>
+    </string-array>
+    <string-array name="max_playback_speed_values">
+        <item>2</item>
+        <item>3</item>
+        <item>5</item>
+        <item>10</item>
     </string-array>
 
     <string name="prefer_original_audio_key">prefer_original_audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="brightness">Brightness</string>
     <string name="volume">Volume</string>
     <string name="none">None</string>
+    <string name="max_playback_speed_title">Maximum playback speed</string>
+    <string name="max_playback_speed_summary">Choose the maximum playback speed</string>
     <string name="show_search_suggestions_title">Search suggestions</string>
     <string name="show_search_suggestions_summary">Choose the suggestions to show when searching</string>
     <string name="local_search_suggestions">Local search suggestions</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -218,6 +218,16 @@
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="@string/default_max_playback_speed_value"
+            android:entries="@array/max_playback_speed_description"
+            android:entryValues="@array/max_playback_speed_values"
+            android:key="@string/max_playback_speed_key"
+            android:summary="@string/max_playback_speed_summary"
+            android:title="@string/max_playback_speed_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="@string/popup_remember_size_pos_key"


### PR DESCRIPTION
While I personally would never want to go above 3x, others ask for up to 10x.

Having 10x does seem to fit everyone at first, but it gets quite frustrating, if you use my swipe to change speed feature and can only use 30% of it's range.

With this setting now, everyone can choose their desired upper limit (from options 2x, 3x, 5x and 10x) in settings and the speed dialog will obey as well as the swiping action.