### PR TITLE
Make middle swipe area adjustable

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -275,8 +275,12 @@ class MainPlayerGestureListener(
 
     override fun getDisplayPortion(e: MotionEvent): DisplayPortion {
         return when {
-            e.x < binding.root.width * 0.3 -> DisplayPortion.LEFT
-            e.x > binding.root.width * 0.7 -> DisplayPortion.RIGHT
+            e.x < binding.root.width *
+                (0.5 - PlayerHelper.getMiddleGestureWidth(player.context) / 2.0)
+            -> DisplayPortion.LEFT
+            e.x > binding.root.width *
+                (0.5 + PlayerHelper.getMiddleGestureWidth(player.context) / 2.0)
+            -> DisplayPortion.RIGHT
             else -> DisplayPortion.MIDDLE
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -246,6 +246,12 @@ public final class PlayerHelper {
                         context.getString(R.string.default_left_gesture_control_value));
     }
 
+    public static double getMiddleGestureWidth(@NonNull final Context context) {
+        return Float.parseFloat(getPreferences(context).getString(
+                context.getString(R.string.middle_gesture_area_width_key),
+                context.getString(R.string.default_middle_gesture_area_width_value)));
+    }
+
     public static boolean isStartMainPlayerFullscreenEnabled(@NonNull final Context context) {
         return getPreferences(context)
                 .getBoolean(context.getString(R.string.start_main_player_fullscreen_key), false);

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -249,6 +249,21 @@
         <item>@string/none_control_key</item>
     </string-array>
 
+    <string name="middle_gesture_area_width_key">middle_gesture_area_width</string>
+    <string name="default_middle_gesture_area_width_value">.3333</string>
+    <string-array name="middle_gesture_area_width_description_list">
+        <item>15%</item>
+        <item>25%</item>
+        <item>33%</item>
+        <item>40%</item>
+    </string-array>
+    <string-array name="middle_gesture_area_width_values_list">
+        <item>.15</item>
+        <item>.25</item>
+        <item>.3333</item>
+        <item>.4</item>
+    </string-array>
+
     <string name="prefer_original_audio_key">prefer_original_audio</string>
     <string name="prefer_descriptive_audio_key">prefer_descriptive_audio</string>
     <string name="last_resize_mode">last_resize_mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="middle_gesture_control_title">Middle gesture action</string>
     <string name="right_gesture_control_summary">Choose gesture for right part of player screen</string>
     <string name="right_gesture_control_title">Right gesture action</string>
+    <string name="middle_gesture_width_summary">Choose area width for middle part of player screen</string>
+    <string name="middle_gesture_width_title">Middle gesture area width</string>
     <string name="brightness">Brightness</string>
     <string name="volume">Volume</string>
     <string name="none">None</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -218,6 +218,16 @@
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="@string/default_middle_gesture_area_width_value"
+            android:entries="@array/middle_gesture_area_width_description_list"
+            android:entryValues="@array/middle_gesture_area_width_values_list"
+            android:key="@string/middle_gesture_area_width_key"
+            android:summary="@string/middle_gesture_width_summary"
+            android:title="@string/middle_gesture_width_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="@string/popup_remember_size_pos_key"


### PR DESCRIPTION
The width of the middle gesture area can now be chosen between 15, 25, 33 and 40 percent. the rest is distributed evenly between left and right area