### PR TITLE
[Feature] Allow seek instead of skip on external media button event

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -304,6 +304,11 @@ public final class PlayerHelper {
         return isUsingInexactSeek(context) ? SeekParameters.CLOSEST_SYNC : SeekParameters.EXACT;
     }
 
+    public static boolean getSeekInsteadOfSkip(@NonNull final Context context) {
+        return getPreferences(context).getBoolean(
+                context.getString(R.string.seek_on_media_button_events_key), false);
+    }
+
     public static long getPreferredCacheSize() {
         return 64 * 1024 * 1024L;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -18,6 +18,7 @@ import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
 import com.google.android.exoplayer2.util.Util;
 
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.util.image.ImageStrategy;
@@ -73,7 +74,11 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
 
     @Override
     public void onSkipToPrevious(@NonNull final com.google.android.exoplayer2.Player exoPlayer) {
-        player.playPrevious();
+        if (PlayerHelper.getSeekInsteadOfSkip(player.getContext())) {
+            player.fastRewind();
+        } else {
+            player.playPrevious();
+        }
     }
 
     @Override
@@ -86,7 +91,11 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
 
     @Override
     public void onSkipToNext(@NonNull final com.google.android.exoplayer2.Player exoPlayer) {
-        player.playNext();
+        if (PlayerHelper.getSeekInsteadOfSkip(player.getContext())) {
+            player.fastForward();
+        } else {
+            player.playNext();
+        }
     }
 
     private void publishFloatingQueueWindow() {

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -24,6 +24,7 @@
     <string name="screen_brightness_timestamp_key">screen_brightness_timestamp_key</string>
     <string name="clear_queue_confirmation_key">clear_queue_confirmation_key</string>
     <string name="ignore_hardware_media_buttons_key">ignore_hardware_media_buttons_key</string>
+    <string name="seek_on_media_button_events_key">seek_on_media_button_events_key</string>
 
     <string name="popup_saved_width_key">popup_saved_width</string>
     <string name="popup_saved_x_key">popup_saved_x</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="clear_queue_confirmation_description">The active player queue will be replaced</string>
     <string name="ignore_hardware_media_buttons_title">Ignore hardware media button events</string>
     <string name="ignore_hardware_media_buttons_summary">Useful, for instance, if you are using a headset with broken physical buttons</string>
+    <string name="seek_on_media_button_events_title">Seek instead of skipping on external media button events</string>
+    <string name="seek_on_media_button_events_summary">Imitates behaviour of most Podcast apps</string>
     <string name="show_comments_title">Show comments</string>
     <string name="show_comments_summary">Turn off to hide comments</string>
     <string name="show_next_and_similar_title">Show \'Next\' and \'Similar\' videos</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -259,5 +259,13 @@
             android:title="@string/ignore_hardware_media_buttons_title"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/seek_on_media_button_events_key"
+            android:summary="@string/seek_on_media_button_events_summary"
+            android:title="@string/seek_on_media_button_events_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
As I use Tubular to listen to many videos in audio only mode while my phone is in my pocket, I often forget, if I am listening to a youtube video or a podcast and automatically tap three times onto my headset to seek back a few seconds if I missed something, as I am used to do with any podcast app.

Unfortunately Tubular then restarts the whole track instead of rewinding and I hate that. :laughing: 

This adds a setting to allow changing the behaviour to seeking.

Of course, it is OFF by default. They, who want it, can activate it.
